### PR TITLE
Added -n arugment to output without units. Also fixed some tests.

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/bcicen/go-units"
@@ -17,11 +18,13 @@ var (
 		"e.g xiny 20kg in lbs\n",
 		"options",
 	}
-	versionStr = fmt.Sprintf("xiny version %s, build %s", version, build)
+	versionStr        = fmt.Sprintf("xiny version %s, build %s", version, build)
+	displayUnits bool = true
 )
 
 var opts = []Opt{
 	{"i", "start xiny in interactive mode", func() { interactive() }},
+	{"n", "display only numeric output (exclude units)", func() { displayUnits = false }},
 	{"v", "enable verbose output", func() { log.Level = log.INFO }},
 	{"vv", "enable debug output", func() { log.Level = log.DEBUG }},
 	{"version", "print version info and exit", func() { fmt.Println(versionStr); os.Exit(0) }},
@@ -134,7 +137,13 @@ func doConvert(cmd string) string {
 	}
 	log.Infof("%s -> %s: %s", fromUnit.Name, toUnit.Name, formula)
 
-	return units.NewValue(x, toUnit).String()
+	var out string
+	if displayUnits {
+		out = units.NewValue(x, toUnit).String()
+	} else {
+		out = strconv.FormatFloat(x, 'f', 6, 64)
+	}
+	return out
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -26,21 +26,21 @@ func TestParseCmd(t *testing.T) {
 	}
 
 	for _, cmd := range cmds {
-		convCmd, err := parseCmd(cmd)
+		amount, fromStr, toStr, err := parseCmd(cmd)
 		if err != nil {
 			t.Errorf("unexpected parse error: %s", err)
 			continue
 		}
-		if math.Abs(convCmd.amount) != 20 {
-			t.Errorf("parsed unexpected value: %v", convCmd.amount)
+		if math.Abs(amount) != 20 {
+			t.Errorf("parsed unexpected value: %v", amount)
 			continue
 		}
-		t.Logf("parsed conversion: %s", convCmd)
+		t.Logf("parsed conversion: %s to %s", fromStr, toStr)
 	}
 }
 
 func TestParseCmdFailure(t *testing.T) {
-	_, err := parseCmd("20kg in")
+	amount, fromStr, toStr, err := parseCmd("20kg in")
 	if err == nil {
 		t.Errorf("missing expected parse error")
 	}
@@ -61,7 +61,7 @@ func TestUnitNameOverlap(t *testing.T) {
 	nameMap := make(map[string]units.Unit)
 
 	var total, failed int
-	for _, u := range units.UnitMap {
+	for _, u := range nameMap {
 		for _, name := range u.Names() {
 			if existing, ok := nameMap[name]; ok {
 				t.Errorf("overlap in unit names: %s, %s (%s)", u.Name, existing.Name, name)


### PR DESCRIPTION
Hey Bradley, Bradley here.

I really like your utility.

I wanted to be able to use your library to output a conversion and then pipe it to another command. I added the argument -n. Used: xiny -n 20kg in pounds. This will just output the numeric value. I am not really a golang developer, so I hope my change doesn't suck too bad. I also tried to fix the tests in main_tests.go. I was able to get the first few passing but had trouble with ./main_test.go:82:20: undefined: QuantityMap. I think the struct was removed from the code previously. Anyway, I'm happy to fix anything in my PR, and you can merge or not merge as you please. 